### PR TITLE
feat(custom_val): allow underscores in custom values

### DIFF
--- a/bin/release_chart
+++ b/bin/release_chart
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e 
+set -e
 
 # helper functions
 msg() { echo -e "\e[32mINFO ---> $1\e[0m"; }
@@ -14,7 +14,7 @@ processCustomVals() {
 
 	for var in $vars
 	do
-		local varName=$(echo $var | sed 's/^custom_//gI' | sed 's/_/./g')
+		local varName=$(echo $var | sed 's/^custom_//gI' | sed 's/_/./g' | sed 's/\.\./_/g')
 		local varValue=$(eval "echo \$$var")
 		resultedArgs="$resultedArgs --set $varName=$varValue"
 	done


### PR DESCRIPTION
## Description

Allow underscores in custom values by doubling them

ex.: `custom_app_logging__level` will result in `app.loging_level`