### PR TITLE
made helm option --recreate-pods optional using environment variable

### DIFF
--- a/bin/release_chart
+++ b/bin/release_chart
@@ -49,6 +49,7 @@ processCustomFlags() {
 
 	[ "$DEBUG_CHART" == "true" ] && flags="$flags --debug"
 	[ "$DRY_RUN" == "true" ] && flags="$flags --dry-run"
+	[ "$RECREATE_PODS" == "true" ] && flags="$flags --recreate-pods"
 	[ ! -z "$TIMEOUT" ] && flags="$flags --timeout $TIMEOUT"
 
 	if [ "$WAIT" == "true" ] || [ -z "$WAIT" ]; then
@@ -121,7 +122,7 @@ if [ ! -z "${CHART_REPO_URL}" ]; then
 fi
 
 msg "Release helm chart"
-helmCmd="helm upgrade $release $chart --install $repoUrl $version $customFlags --force --reset-values --recreate-pods --namespace $namespace $customVals"
+helmCmd="helm upgrade $release $chart --install $repoUrl $version $customFlags --force --reset-values --namespace $namespace $customVals"
 
 msg "Running helm upgrade (--install) command ..."
 msg "$helmCmd"


### PR DESCRIPTION
having the option --recreate-pods systematically applied leads to system unavaibility (>30 seconds in our cases)

